### PR TITLE
Warn if action policy cannot be parsed

### DIFF
--- a/util/actionpolicy.rb
+++ b/util/actionpolicy.rb
@@ -56,7 +56,7 @@ module MCollective
               end
             end
           else
-            Log.debug("Cannot parse policy line: %s" % line)
+            Log.warn("Cannot parse policy %s line: %s" % [policy_file, line])
           end
         end
 


### PR DESCRIPTION
After having an error in one of my own files this would have been useful.