### PR TITLE
MCOP-583 Support groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,8 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-  gem 'rspec', '~> 2.11.0'
-  gem 'mocha', '~> 0.10.0'
-  gem 'mcollective-test'
+  gem 'rspec', '~> 3.5.0'
+  gem 'mocha', '~> 1.2.0'
 end
 
 mcollective_version = ENV['MCOLLECTIVE_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -89,11 +89,30 @@ Policy files must have the following format:
 
 ### Caller ID
 
-Caller ID strings are always of the form `<kind>=<value>`, but both the kind and the value of the ID will depend on your security plugin. See your security plugin's documentation or code for details. Multiple Caller IDs separated by spaces are supported to allow grouping similar callers together.
+In the case of a single user the Caller ID strings are always of the form `<kind>=<value>`, but both the kind and the value of the ID will depend on your security plugin. See your security plugin's documentation or code for details. Multiple Caller IDs separated by spaces are supported to allow grouping similar callers together.
+
+You can also define named groups of callers like `sysadmin`, see the Groups section below.
 
 * The recommended SSL security plugin sets caller IDs of `cert=<NAME>`, where `<NAME>` is the filename of the client's public key file (minus the `.pem` extension). So a request validated with the `puppet-admins.pem` public key file would be given a caller ID of `cert=puppet-admins`. This kind of caller ID is cryptographically authenticated.
 * The PSK security plugin defaults to caller IDs of `uid=<UID>`, where `<UID>` is the local UID of the client process. [There are several other options available](https://github.com/puppetlabs/marionette-collective/blob/master/plugins/mcollective/security/psk.rb#L79), which can be configured with the `plugin.psk.callertype` setting. **None of PSK's caller IDs are authenticated,** and you should generally not be relying on authorization at all if you are using the PSK security plugin.
 
+
+### Groups
+
+You can create a file called `<configdir>/policies/groups` with content as here:
+
+    # sample groups file
+    sysadmins cert=sa1 cert=sa2
+
+Fields are space separated, group names should match `^([\w\.\-]+)$`
+
+Here we create a `sysadmins` group that has 2 Caller IDs in it, the same rules as above for Caller IDs apply here.  Only Caller IDs can be references not other groups.
+
+This group can then be used where you would normal put a Caller ID:
+
+    allow   sysadmins      *                       customer=acme    acme::devserver
+
+You can list multiple groups in space separated lists.  You cannot mix certnames and group names in the same policy line.
 
 Hardcoding ActionPolicy Into a Specific Agent
 ============================

--- a/spec/actionpolicy/actionpolicy_spec.rb
+++ b/spec/actionpolicy/actionpolicy_spec.rb
@@ -6,26 +6,80 @@ require File.join(File.dirname(__FILE__), '../../', 'util', 'actionpolicy.rb')
 module MCollective
   module Util
     describe ActionPolicy do
-      let(:request) do
-        request = mock
-        request.stubs(:agent).returns('rspec_agent')
-        request.stubs(:caller).returns('rspec_caller')
-        request.stubs(:action).returns('rspec_action')
-        request
-      end
-
-      let(:config) do
-        config = mock
-        config.stubs(:configdir).returns('/rspecdir')
-        config.stubs(:pluginconf).returns({})
-        config
-      end
-
+      let(:request) { stub(:agent => 'rspec_agent', :caller => 'rspec_caller', :action => 'rspec_action') }
+      let(:config) { stub(:configdir => '/rspecdir', :pluginconf => {}) }
+      let(:fixtures_dir) { File.join(File.dirname(__FILE__), 'fixtures') }
       let(:actionpolicy) { ActionPolicy.new(request) }
 
       before do
         Config.stubs(:instance).returns(config)
-        @fixtures_dir = File.join(File.dirname(__FILE__), 'fixtures')
+      end
+
+      describe "#action_in_actions?" do
+        it 'should correctly determine if the action is in the actions' do
+          expect(actionpolicy.action_in_actions?('one two three')).to be(false)
+          expect(actionpolicy.action_in_actions?('rspec_action another_action')).to be(true)
+          expect(actionpolicy.action_in_actions?('another_action rspec_action')).to be(true)
+        end
+      end
+
+      describe '#caller_in_groups?' do
+        before(:each) do
+          Log.stubs(:debug)
+          actionpolicy.parse_group_file(File.join(fixtures_dir, "groups"))
+        end
+
+        it 'should return false for nil groups' do
+          expect(actionpolicy.caller_in_groups?(nil)).to be(false)
+        end
+
+        it 'should find the caller in the groups' do
+          expect(actionpolicy.caller_in_groups?("sysadmin")).to be(true)
+          expect(actionpolicy.caller_in_groups?("app_admin")).to be(false)
+          expect(actionpolicy.caller_in_groups?("single_group")).to be(true)
+          expect(actionpolicy.caller_in_groups?("foo")).to be(false)
+        end
+      end
+
+      describe '#caller_in_callerids?' do
+        it 'should correctly determine if the caller is in the ids' do
+          expect(actionpolicy.caller_in_callerids?('one two three')).to be(false)
+          expect(actionpolicy.caller_in_callerids?('rspec_caller another_caller')).to be(true)
+          expect(actionpolicy.caller_in_callerids?('another_caller rspec_caller')).to be(true)
+        end
+      end
+
+      describe '#parse_group_file' do
+        before(:each) do
+          Log.stubs(:debug)
+          Log.stubs(:warn)
+        end
+
+        it 'should do nothing for nil groups files' do
+          expect(actionpolicy.parse_group_file(nil)).to be_nil
+        end
+
+        it 'should do nothing for non existing group files' do
+          File.expects(:exist?).with('/nonexisting/g_file').returns(false)
+          expect(actionpolicy.parse_group_file('/nonexisting/g_file')).to be_nil
+        end
+
+        it 'should do nothing for unreadable group files' do
+          File.expects(:exist?).with('/nonexisting/g_file').returns(true)
+          File.expects(:readable?).with('/nonexisting/g_file').returns(false)
+          expect(actionpolicy.parse_group_file('/nonexisting/g_file')).to be_nil
+        end
+
+        it 'should parse the groups correctly' do
+          groups = actionpolicy.parse_group_file(File.join(fixtures_dir, 'groups'))
+
+          # specifically verifies that only valid groups are in the list
+          expect(groups).to eq(
+            'sysadmin' => ['cert=sa1', 'cert=sa2', 'rspec_caller'],
+            'app_admin' => ['cert=aa1', 'cert=aa2'],
+            'single_group' => ['rspec_caller'],
+          )
+        end
       end
 
       describe '#authorize' do
@@ -40,7 +94,7 @@ module MCollective
         it 'should set the default values' do
           actionpolicy.config.should == config
           actionpolicy.agent.should == 'rspec_agent'
-          actionpolicy.caller.should == 'rspec_caller'
+          actionpolicy.caller_id.should == 'rspec_caller'
           actionpolicy.action.should == 'rspec_action'
           actionpolicy.allow_unconfigured.should == false
           actionpolicy.configdir.should == '/rspecdir'
@@ -114,30 +168,30 @@ module MCollective
         # Fixtures
 
         it 'should parse the default alllow policy' do
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'default_allow')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'default_allow')).should be_true
         end
 
         it 'should parse the default deny policy' do
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'default_deny'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'default_deny'))
           }.to raise_error RPCAborted
         end
 
         # Example fixtures
 
         it 'should parse example1 correctly' do
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example1')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example1')).should be_true
         end
 
         it 'should parse example2 correctly' do
           request.stubs(:caller).returns('uid=500')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example2')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example2')).should be_true
 
           request.stubs(:caller).returns('uid=501')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example2'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example2'))
           }.to raise_error RPCAborted
 
         end
@@ -145,34 +199,34 @@ module MCollective
         it 'should parse example3 correctly' do
           request.stubs(:action).returns('rspec')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example3')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example3')).should be_true
 
           request.stubs(:action).returns('notrspec')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example3'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example3'))
           }.to raise_error RPCAborted
 
         end
 
         it 'should parse example4 correctly' do
           Util.stubs(:get_fact).with('foo').returns('bar')
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example4')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example4')).should be_true
 
           Util.stubs(:get_fact).with('foo').returns('notbar')
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example4'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example4'))
           }.to raise_error RPCAborted
 
         end
 
         it 'should parse example5 correctly' do
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example5')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example5')).should be_true
 
           Util.stubs(:has_cf_class?).with('rspec').returns(false)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example5'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example5'))
           }.to raise_error RPCAborted
 
         end
@@ -181,13 +235,13 @@ module MCollective
           request.stubs(:caller).returns('uid=500')
           request.stubs(:action).returns('rspec')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example6')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example6')).should be_true
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example6'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example6'))
           }.to raise_error RPCAborted
 
         end
@@ -196,13 +250,13 @@ module MCollective
           request.stubs(:caller).returns('uid=500')
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example7')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example7')).should be_true
 
           request.stubs(:caller).returns('uid=501')
           Util.stubs(:get_fact).with('foo').returns('notbar')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example7'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example7'))
           }.to raise_error RPCAborted
 
         end
@@ -211,12 +265,12 @@ module MCollective
           request.stubs(:caller).returns('uid=500')
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example8')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example8')).should be_true
 
           Util.stubs(:has_cf_class?).with('rspec').returns(false)
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example8'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example8'))
           }.to raise_error RPCAborted
 
         end
@@ -226,14 +280,14 @@ module MCollective
           request.stubs(:action).returns('rspec')
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example9')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example9')).should be_true
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
           Util.stubs(:get_fact).with('foo').returns('notbar')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example9'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example9'))
           }.to raise_error RPCAborted
 
         end
@@ -243,14 +297,14 @@ module MCollective
           request.stubs(:action).returns('rspec')
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example10')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10')).should be_true
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
           Util.stubs(:has_cf_class?).with('rspec').returns(false)
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example10'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10'))
           }.to raise_error RPCAborted
 
 
@@ -263,7 +317,7 @@ module MCollective
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example10')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10')).should be_true
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
@@ -271,7 +325,7 @@ module MCollective
           Util.stubs(:get_fact).with('foo').returns('notbar')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example10'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10'))
           }.to raise_error RPCAborted
         end
 
@@ -282,7 +336,7 @@ module MCollective
           Util.stubs(:get_fact).with('foo').returns('bar')
           Util.stubs(:get_fact).with('bar').returns('foo')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example12')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example12')).should be_true
         end
 
         it 'should parse example13 correctly' do
@@ -293,7 +347,7 @@ module MCollective
           Util.stubs(:has_cf_class?).with('three').returns(false)
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example13')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example13')).should be_true
         end
 
         it 'should parse example14 correctly' do
@@ -303,35 +357,35 @@ module MCollective
           Util.stubs(:has_cf_class?).with('two').returns(false)
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example14')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example14')).should be_true
         end
 
         it 'should parse example15 correctly' do
           # first field
           request.stubs(:caller).returns('uid=500')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example15')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
 
           # second field
           request.stubs(:caller).returns('uid=600')
           Util.stubs(:get_fact).with('customer').returns('acme')
           Util.stubs(:has_cf_class?).with('acme::devserver').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example15')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
 
           # third field
           request.stubs(:caller).returns('uid=600')
           request.stubs(:action).returns('status')
           Util.stubs(:get_fact).with('customer').returns('acme')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example15')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
 
           # forth field
           request.stubs(:caller).returns('uid=600')
           request.stubs(:action).returns('status')
           Util.stubs(:get_fact).with('customer').returns('acme')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example15')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
 
           # fith field
           request.stubs(:caller).returns('uid=700')
@@ -339,7 +393,7 @@ module MCollective
           Util.stubs(:get_fact).with('environment').returns('development')
           Matcher.stubs(:eval_compound_fstatement).with('value' => 'enabled', 'name' => 'puppet', 'operator' => '==', 'params' => nil, 'r_compare' => 'false').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example15')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
 
 
         end
@@ -348,20 +402,26 @@ module MCollective
           # match uid in the list
           request.stubs(:caller).returns('uid=600')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example16')).should be_true
+          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example16')).should be_true
 
           # match uid not in the list
           request.stubs(:caller).returns('uid=800')
           actionpolicy = ActionPolicy.new(request)
           expect{
-            actionpolicy.parse_policy_file(File.join(@fixtures_dir, 'example16'))
+            actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example16'))
           }.to raise_error RPCAborted
         end
       end
 
       describe '#check_policy' do
+        before(:each) do
+          Log.stubs(:debug)
+          actionpolicy.parse_group_file(File.join(fixtures_dir, "groups"))
+        end
+
         it 'should return false if the policy line does not include the caller' do
           actionpolicy.check_policy('caller', nil, nil, nil).should be_false
+          actionpolicy.check_policy('app_admin', nil, nil, nil).should be_false
         end
 
         it 'should return false if the policy line does not include the action' do
@@ -369,9 +429,10 @@ module MCollective
         end
 
         it 'should parse both facts and classes if callers and actions match' do
-          actionpolicy.expects(:parse_facts).with('*').returns(true)
-          actionpolicy.expects(:parse_classes).with('*').returns(true)
+          actionpolicy.expects(:parse_facts).with('*').returns(true).twice
+          actionpolicy.expects(:parse_classes).with('*').returns(true).twice
           actionpolicy.check_policy('rspec_caller', 'rspec_action', '*', '*').should be_true
+          actionpolicy.check_policy('sysadmin', 'rspec_action', '*', '*').should be_true
         end
 
         it 'should parse a compound statement if callers and actions match but classes are excluded' do
@@ -477,9 +538,9 @@ module MCollective
           actionpolicy.lookup_policy_file.should == '/rspecdir/policies/rspec.policy'
         end
 
-        it 'should return nil if no policy file exists' do
+        it 'should return false if no policy file exists' do
           File.expects(:exist?).with('/rspecdir/policies/rspec_agent.policy').returns(false)
-          actionpolicy.lookup_policy_file.should == nil
+          actionpolicy.lookup_policy_file.should == false
         end
       end
 

--- a/spec/actionpolicy/actionpolicy_spec.rb
+++ b/spec/actionpolicy/actionpolicy_spec.rb
@@ -92,18 +92,21 @@ module MCollective
 
       describe '#initialize' do
         it 'should set the default values' do
-          actionpolicy.config.should == config
-          actionpolicy.agent.should == 'rspec_agent'
-          actionpolicy.caller_id.should == 'rspec_caller'
-          actionpolicy.action.should == 'rspec_action'
-          actionpolicy.allow_unconfigured.should == false
-          actionpolicy.configdir.should == '/rspecdir'
+          expect(actionpolicy.config).to be(config)
+          expect(actionpolicy.agent).to eq('rspec_agent')
+          expect(actionpolicy.caller_id).to eq('rspec_caller')
+          expect(actionpolicy.action).to eq('rspec_action')
+          expect(actionpolicy.allow_unconfigured).to be(false)
+          expect(actionpolicy.configdir).to eq('/rspecdir')
+          expect(actionpolicy.groups).to eq({})
+          expect(actionpolicy.enable_default).to be(false)
+          expect(actionpolicy.default_name).to eq('default')
         end
 
         it 'should set allow_unconfigured if set in config file' do
           config.stubs(:pluginconf).returns({'actionpolicy.allow_unconfigured' => '1'})
           result = ActionPolicy.new(request)
-          result.allow_unconfigured.should == true
+          expect(result.allow_unconfigured).to be(true)
         end
       end
 
@@ -113,7 +116,7 @@ module MCollective
         end
 
         it 'should deny the request if policy file does not exist and allow_unconfigured is false' do
-          ActionPolicy.any_instance.expects(:lookup_policy_file).returns(nil)
+          actionpolicy.expects(:lookup_policy_file).returns(nil)
 
           expect{
             actionpolicy.authorize_request
@@ -121,23 +124,23 @@ module MCollective
         end
 
         it 'should return true if policy file does not exist but allow_unconfigured is true' do
-          ActionPolicy.any_instance.expects(:lookup_policy_file).returns(nil)
-          config.stubs(:pluginconf).returns({'actionpolicy.allow_unconfigured' => 'y'})
+          actionpolicy.expects(:lookup_policy_file).returns(nil)
+          actionpolicy.allow_unconfigured = true
 
-          actionpolicy.authorize_request.should be_true
+          expect(actionpolicy.authorize_request).to be(true)
         end
 
         it 'should parse the policy file if it exists' do
-          ActionPolicy.any_instance.expects(:lookup_policy_file).returns('/rspecdir/policyfile')
-          ActionPolicy.any_instance.expects(:parse_policy_file).with('/rspecdir/policyfile')
+          actionpolicy.expects(:lookup_policy_file).returns('/rspecdir/policyfile')
+          actionpolicy.expects(:parse_policy_file).with('/rspecdir/policyfile')
           actionpolicy.authorize_request
         end
 
         it 'should enforce precedence of enable_default over allow_unconfigured' do
-          config.stubs(:pluginconf).returns({'actionpolicy.allow_unconfigured' => 'y',
-                                             'actionpolicy.enable_default' => 'y'})
-          ActionPolicy.any_instance.expects(:lookup_policy_file).returns('/rspec/default')
-          ActionPolicy.any_instance.expects(:parse_policy_file).with('/rspec/default')
+          actionpolicy.allow_unconfigured = true
+          actionpolicy.enable_default = true
+          actionpolicy.expects(:lookup_policy_file).returns('/rspec/default')
+          actionpolicy.expects(:parse_policy_file).with('/rspec/default')
           actionpolicy.authorize_request
 
         end
@@ -168,7 +171,7 @@ module MCollective
         # Fixtures
 
         it 'should parse the default alllow policy' do
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'default_allow')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'default_allow'))).to be(true)
         end
 
         it 'should parse the default deny policy' do
@@ -180,13 +183,13 @@ module MCollective
         # Example fixtures
 
         it 'should parse example1 correctly' do
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example1')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example1'))).to be(true)
         end
 
         it 'should parse example2 correctly' do
           request.stubs(:caller).returns('uid=500')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example2')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example2'))).to be(true)
 
           request.stubs(:caller).returns('uid=501')
           actionpolicy = ActionPolicy.new(request)
@@ -199,7 +202,7 @@ module MCollective
         it 'should parse example3 correctly' do
           request.stubs(:action).returns('rspec')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example3')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example3'))).to be(true)
 
           request.stubs(:action).returns('notrspec')
           actionpolicy = ActionPolicy.new(request)
@@ -211,7 +214,7 @@ module MCollective
 
         it 'should parse example4 correctly' do
           Util.stubs(:get_fact).with('foo').returns('bar')
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example4')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example4'))).to be(true)
 
           Util.stubs(:get_fact).with('foo').returns('notbar')
           expect{
@@ -222,7 +225,7 @@ module MCollective
 
         it 'should parse example5 correctly' do
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example5')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example5'))).to be(true)
 
           Util.stubs(:has_cf_class?).with('rspec').returns(false)
           expect{
@@ -235,7 +238,7 @@ module MCollective
           request.stubs(:caller).returns('uid=500')
           request.stubs(:action).returns('rspec')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example6')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example6'))).to be(true)
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
@@ -250,7 +253,7 @@ module MCollective
           request.stubs(:caller).returns('uid=500')
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example7')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example7'))).to be(true)
 
           request.stubs(:caller).returns('uid=501')
           Util.stubs(:get_fact).with('foo').returns('notbar')
@@ -265,7 +268,7 @@ module MCollective
           request.stubs(:caller).returns('uid=500')
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example8')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example8'))).to be(true)
 
           Util.stubs(:has_cf_class?).with('rspec').returns(false)
           actionpolicy = ActionPolicy.new(request)
@@ -280,7 +283,7 @@ module MCollective
           request.stubs(:action).returns('rspec')
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example9')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example9'))).to be(true)
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
@@ -297,7 +300,7 @@ module MCollective
           request.stubs(:action).returns('rspec')
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10'))).to be(true)
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
@@ -317,7 +320,7 @@ module MCollective
           Util.stubs(:has_cf_class?).with('rspec').returns(true)
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example10'))).to be(true)
 
           request.stubs(:caller).returns('uid=501')
           request.stubs(:action).returns('notrspec')
@@ -336,7 +339,7 @@ module MCollective
           Util.stubs(:get_fact).with('foo').returns('bar')
           Util.stubs(:get_fact).with('bar').returns('foo')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example12')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example12'))).to be(true)
         end
 
         it 'should parse example13 correctly' do
@@ -347,7 +350,7 @@ module MCollective
           Util.stubs(:has_cf_class?).with('three').returns(false)
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example13')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example13'))).to be(true)
         end
 
         it 'should parse example14 correctly' do
@@ -357,35 +360,35 @@ module MCollective
           Util.stubs(:has_cf_class?).with('two').returns(false)
           Util.stubs(:get_fact).with('foo').returns('bar')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example14')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example14'))).to be(true)
         end
 
         it 'should parse example15 correctly' do
           # first field
           request.stubs(:caller).returns('uid=500')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15'))).to be(true)
 
           # second field
           request.stubs(:caller).returns('uid=600')
           Util.stubs(:get_fact).with('customer').returns('acme')
           Util.stubs(:has_cf_class?).with('acme::devserver').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15'))).to be(true)
 
           # third field
           request.stubs(:caller).returns('uid=600')
           request.stubs(:action).returns('status')
           Util.stubs(:get_fact).with('customer').returns('acme')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15'))).to be(true)
 
           # forth field
           request.stubs(:caller).returns('uid=600')
           request.stubs(:action).returns('status')
           Util.stubs(:get_fact).with('customer').returns('acme')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15'))).to be(true)
 
           # fith field
           request.stubs(:caller).returns('uid=700')
@@ -393,16 +396,14 @@ module MCollective
           Util.stubs(:get_fact).with('environment').returns('development')
           Matcher.stubs(:eval_compound_fstatement).with('value' => 'enabled', 'name' => 'puppet', 'operator' => '==', 'params' => nil, 'r_compare' => 'false').returns(true)
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15')).should be_true
-
-
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example15'))).to be(true)
         end
 
         it 'should parse example16 correctly' do
           # match uid in the list
           request.stubs(:caller).returns('uid=600')
           actionpolicy = ActionPolicy.new(request)
-          actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example16')).should be_true
+          expect(actionpolicy.parse_policy_file(File.join(fixtures_dir, 'example16'))).to be(true)
 
           # match uid not in the list
           request.stubs(:caller).returns('uid=800')
@@ -420,96 +421,96 @@ module MCollective
         end
 
         it 'should return false if the policy line does not include the caller' do
-          actionpolicy.check_policy('caller', nil, nil, nil).should be_false
-          actionpolicy.check_policy('app_admin', nil, nil, nil).should be_false
+          expect(actionpolicy.check_policy('caller', nil, nil, nil)).to be(false)
+          expect(actionpolicy.check_policy('app_admin', nil, nil, nil)).to be(false)
         end
 
         it 'should return false if the policy line does not include the action' do
-          actionpolicy.check_policy(nil, 'action', nil, nil).should be_false
+          expect(actionpolicy.check_policy(nil, 'action', nil, nil)).to be(false)
         end
 
         it 'should parse both facts and classes if callers and actions match' do
           actionpolicy.expects(:parse_facts).with('*').returns(true).twice
           actionpolicy.expects(:parse_classes).with('*').returns(true).twice
-          actionpolicy.check_policy('rspec_caller', 'rspec_action', '*', '*').should be_true
-          actionpolicy.check_policy('sysadmin', 'rspec_action', '*', '*').should be_true
+          expect(actionpolicy.check_policy('rspec_caller', 'rspec_action', '*', '*')).to be(true)
+          expect(actionpolicy.check_policy('sysadmin', 'rspec_action', '*', '*')).to be(true)
         end
 
         it 'should parse a compound statement if callers and actions match but classes are excluded' do
           actionpolicy.expects(:parse_compound).with('*').returns(true)
-          actionpolicy.check_policy('rspec_caller', 'rspec_action', '*', nil).should be_true
+          expect(actionpolicy.check_policy('rspec_caller', 'rspec_action', '*', nil)).to be(true)
         end
       end
 
       describe '#parse_facts' do
         it 'should return true if facts is a wildcard' do
-          actionpolicy.parse_facts('*').should be_true
+          expect(actionpolicy.parse_facts('*')).to be(true)
         end
 
         it 'should parse compound fact statements' do
           actionpolicy.stubs(:is_compound?).returns(true)
           actionpolicy.expects(:parse_compound).with('foo=bar and bar=foo').returns(true)
-          actionpolicy.parse_facts('foo=bar and bar=foo').should be_true
+          expect(actionpolicy.parse_facts('foo=bar and bar=foo')).to be(true)
         end
 
         it 'should parse all facts' do
           actionpolicy.stubs(:is_compound?).returns(false)
           actionpolicy.expects(:lookup_fact).twice.returns(true)
-          actionpolicy.parse_facts('foo=bar bar=foo').should be_true
+          expect(actionpolicy.parse_facts('foo=bar bar=foo')).to be(true)
         end
       end
 
       describe '#parse_classes' do
         it 'should return true if classes is a wildcard' do
-          actionpolicy.parse_classes('*').should be_true
+          expect(actionpolicy.parse_classes('*')).to be(true)
         end
 
         it 'should parse compound class statements' do
           actionpolicy.stubs(:is_compound?).returns(true)
           actionpolicy.expects(:parse_compound).with('foo=bar and bar=foo').returns(true)
-          actionpolicy.parse_facts('foo=bar and bar=foo').should be_true
+          expect(actionpolicy.parse_facts('foo=bar and bar=foo')).to be(true)
         end
 
         it 'should parse all classes' do
           actionpolicy.stubs(:is_compound?).returns(false)
           actionpolicy.expects(:lookup_fact).times(3).returns(true)
-          actionpolicy.parse_facts('foo bar baz').should be_true
+          expect(actionpolicy.parse_facts('foo bar baz')).to be(true)
         end
       end
 
       describe '#lookup_fact' do
         it 'should return false if a class is found in the fact field' do
           Log.expects(:warn).with('Class found where fact was expected')
-          actionpolicy.lookup_fact('rspec').should be_false
+          expect(actionpolicy.lookup_fact('rspec')).to be(false)
         end
 
         it 'should lookup a fact value and return its true value' do
           Util.expects(:get_fact).with('foo').returns('bar')
-          actionpolicy.lookup_fact('foo=bar').should be_true
+          expect(actionpolicy.lookup_fact('foo=bar')).to be(true)
         end
       end
 
       describe '#lookup_class' do
         it 'should return false if a fact is found in the class field' do
           Log.expects(:warn).with('Fact found where class was expected')
-          actionpolicy.lookup_class('foo=bar').should be_false
+          expect(actionpolicy.lookup_class('foo=bar')).to be(false)
         end
 
         it 'should lookup a fact value and return its true value' do
           Util.expects(:has_cf_class?).with('rspec').returns(true)
-          actionpolicy.lookup_class('rspec').should be_true
+          expect(actionpolicy.lookup_class('rspec')).to be(true)
         end
       end
 
       describe '#lookup' do
         it 'should call #lookup_fact if a fact was passed' do
           actionpolicy.expects(:lookup_fact).with('foo=bar').returns(true)
-          actionpolicy.lookup('foo=bar').should be_true
+          expect(actionpolicy.lookup('foo=bar')).to be(true)
         end
 
         it 'should call #lookup_class if a class was passed' do
           actionpolicy.expects(:lookup_class).with('/rspec/').returns(true)
-          actionpolicy.lookup('/rspec/').should be_true
+          expect(actionpolicy.lookup('/rspec/')).to be(true)
         end
       end
 
@@ -520,14 +521,14 @@ module MCollective
 
         it 'should return the path of the policyfile is present' do
           File.expects(:exist?).with('/rspecdir/policies/rspec_agent.policy').returns(true)
-          actionpolicy.lookup_policy_file.should == '/rspecdir/policies/rspec_agent.policy'
+          expect(actionpolicy.lookup_policy_file).to eq('/rspecdir/policies/rspec_agent.policy')
         end
 
         it 'should return the default file path if one is specified' do
           config.stubs(:pluginconf).returns({'actionpolicy.enable_default' => '1'})
           File.expects(:exist?).with('/rspecdir/policies/rspec_agent.policy').returns(false)
           File.expects(:exist?).with('/rspecdir/policies/default.policy').returns(true)
-          actionpolicy.lookup_policy_file.should == '/rspecdir/policies/default.policy'
+          expect(actionpolicy.lookup_policy_file).to eq('/rspecdir/policies/default.policy')
         end
 
         it 'should return a custom default file path if one is specified' do
@@ -535,49 +536,49 @@ module MCollective
                                              'actionpolicy.default_name' => 'rspec'})
           File.expects(:exist?).with('/rspecdir/policies/rspec_agent.policy').returns(false)
           File.expects(:exist?).with('/rspecdir/policies/rspec.policy').returns(true)
-          actionpolicy.lookup_policy_file.should == '/rspecdir/policies/rspec.policy'
+          expect(actionpolicy.lookup_policy_file).to eq('/rspecdir/policies/rspec.policy')
         end
 
         it 'should return false if no policy file exists' do
           File.expects(:exist?).with('/rspecdir/policies/rspec_agent.policy').returns(false)
-          actionpolicy.lookup_policy_file.should == false
+          expect(actionpolicy.lookup_policy_file).to be(false)
         end
       end
 
       describe '#eval_statement' do
         it 'should return the logical string if param is not an statement or fstatement' do
-          actionpolicy.eval_statement({'and' => 'and'}).should == 'and'
+          expect(actionpolicy.eval_statement({'and' => 'and'})).to eq('and')
         end
 
         it 'should lookup the value of a statement if param is a statement' do
           actionpolicy.expects(:lookup).with('foo=bar').returns(true)
-          actionpolicy.eval_statement({'statement' => 'foo=bar'}).should be_true
+          expect(actionpolicy.eval_statement({'statement' => 'foo=bar'})).to be(true)
         end
 
         it 'should lookup the value of a data function if param is a fstatement' do
           Matcher.expects(:eval_compound_fstatement).with("rspec('data').value=result").returns(true)
-          actionpolicy.eval_statement({'fstatement' => "rspec('data').value=result"}).should be_true
+          expect(actionpolicy.eval_statement({'fstatement' => "rspec('data').value=result"})).to be(true)
         end
 
         it 'should log a failure message and return false if the fstatement cannot be parsed' do
           Matcher.expects(:eval_compound_fstatement).with("rspec('data').value=result").raises('error')
           Log.expects(:warn).with('Could not call Data function in policy file: error')
-          actionpolicy.eval_statement({'fstatement' => "rspec('data').value=result"}).should be_false
+          expect(actionpolicy.eval_statement({'fstatement' => "rspec('data').value=result"})).to be(false)
         end
       end
 
       describe '#is_compound?' do
         it 'should return false if a compound statement was not identified' do
-          actionpolicy.is_compound?('not').should be_true
-          actionpolicy.is_compound?('!rspec').should be_true
-          actionpolicy.is_compound?('and').should be_true
-          actionpolicy.is_compound?('or').should be_true
-          actionpolicy.is_compound?("data('field').value=othervalue").should be_true
+          expect(actionpolicy.is_compound?('not')).to be(true)
+          expect(actionpolicy.is_compound?('!rspec')).to be(true)
+          expect(actionpolicy.is_compound?('and')).to be(true)
+          expect(actionpolicy.is_compound?('or')).to be(true)
+          expect(actionpolicy.is_compound?("data('field').value=othervalue")).to be(true)
         end
 
         it 'should return true if a compound statement was identified' do
-          actionpolicy.is_compound?('f1=v1 f1=v2').should be_false
-          actionpolicy.is_compound?('class1 class2 /class*/').should be_false
+          expect(actionpolicy.is_compound?('f1=v1 f1=v2')).to be(false)
+          expect(actionpolicy.is_compound?('class1 class2 /class*/')).to be(false)
         end
       end
 

--- a/spec/actionpolicy/fixtures/groups
+++ b/spec/actionpolicy/fixtures/groups
@@ -1,0 +1,5 @@
+# line to ignore
+sysadmin cert=sa1 cert=sa2 rspec_caller
+app_admin cert=aa1 cert=aa2
+single_group rspec_caller
+invalid_group

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,14 +3,12 @@ $: << File.join([File.dirname(__FILE__), "lib"])
 require 'rubygems'
 require 'rspec'
 require 'mcollective'
-require 'mcollective/test'
 require 'rspec/mocks'
 require 'mocha'
 require 'tempfile'
 
 RSpec.configure do |config|
   config.mock_with :mocha
-  config.include(MCollective::Test::Matchers)
 
   config.before :each do
     MCollective::PluginManager.clear

--- a/util/actionpolicy.rb
+++ b/util/actionpolicy.rb
@@ -1,7 +1,8 @@
 module MCollective
   module Util
     class ActionPolicy
-      attr_accessor :config, :allow_unconfigured, :configdir, :agent, :caller_id, :action, :groups
+      attr_accessor :config, :allow_unconfigured, :configdir, :agent, :caller_id
+      attr_accessor :action, :groups, :enable_default, :default_name
 
       def self.authorize(request)
         ActionPolicy.new(request).authorize_request
@@ -13,6 +14,8 @@ module MCollective
         @caller_id = request.caller
         @action = request.action
         @allow_unconfigured = !!(config.pluginconf.fetch('actionpolicy.allow_unconfigured', 'n') =~ /^1|y/i)
+        @enable_default = !!(config.pluginconf.fetch('actionpolicy.enable_default', 'n') =~ /^1|y/i)
+        @default_name = config.pluginconf.fetch('actionpolicy.default_name', 'default')
         @configdir = @config.configdir
         @groups = {}
       end
@@ -249,9 +252,8 @@ module MCollective
 
         return policy_file if File.exist?(policy_file)
 
-        if config.pluginconf.fetch('actionpolicy.enable_default', 'n') =~ /^1|y/i
-          defaultname = config.pluginconf.fetch('actionpolicy.default_name', 'default')
-          default_file = File.join(configdir, "policies", "#{defaultname}.policy")
+        if enable_default
+          default_file = File.join(configdir, "policies", "#{default_name}.policy")
 
           Log.debug("Initial lookup failed: looking for policy in #{default_file}")
 

--- a/util/actionpolicy.rb
+++ b/util/actionpolicy.rb
@@ -1,7 +1,7 @@
 module MCollective
   module Util
     class ActionPolicy
-      attr_accessor :config, :allow_unconfigured, :configdir, :agent, :caller, :action
+      attr_accessor :config, :allow_unconfigured, :configdir, :agent, :caller_id, :action, :groups
 
       def self.authorize(request)
         ActionPolicy.new(request).authorize_request
@@ -10,33 +10,44 @@ module MCollective
       def initialize(request)
         @config = Config.instance
         @agent = request.agent
-        @caller = request.caller
+        @caller_id = request.caller
         @action = request.action
         @allow_unconfigured = !!(config.pluginconf.fetch('actionpolicy.allow_unconfigured', 'n') =~ /^1|y/i)
         @configdir = @config.configdir
+        @groups = {}
       end
 
+      # Performs request authorization
+      #
+      # @return [Boolean]
       def authorize_request
         # Lookup the policy file. If none exists and @allow_unconfigured
         # is false the request gets denied.
         policy_file = lookup_policy_file
 
         # No policy file exists and allow_unconfigured is false
-        if !policy_file && !@allow_unconfigured
-          deny('Could not load any valid policy files. Denying based on allow_unconfigured: %s' % @allow_unconfigured)
+        if !policy_file && !allow_unconfigured
+          deny('Could not load any valid policy files. Denying based on allow_unconfigured: %s' % allow_unconfigured)
         # No policy exists but allow_unconfigured is true
-        elsif !(policy_file) && @allow_unconfigured
-          Log.debug('Could not load any valid policy files. Allowing based on allow_unconfigured: %s' % @allow_unconfigured)
+        elsif !(policy_file) && allow_unconfigured
+          Log.debug('Could not load any valid policy files. Allowing based on allow_unconfigured: %s' % allow_unconfigured)
           return true
         end
+
+        parse_group_file(lookup_groups_file)
 
         # A policy file exists
         parse_policy_file(policy_file)
       end
 
+      # Parse and validate the policy file
+      #
+      # @param policy_file [String] path to the policy file
+      # @return [Boolean]
+      # @raize [RPCAborted] when the request does not pass the policy
       def parse_policy_file(policy_file)
-        Log.debug('Parsing policyfile for %s: %s' % [@agent, policy_file])
-        allow = @allow_unconfigured
+        Log.debug('Parsing policyfile for %s: %s' % [agent, policy_file])
+        allow = allow_unconfigured
 
         File.read(policy_file).each_line do |line|
           next if line =~ /^(#.*|\s*)$/
@@ -63,27 +74,91 @@ module MCollective
         allow || deny("Denying based on default policy in %s" % File.basename(policy_file))
       end
 
+      # Parses the group file into the `@groups` memory structure
+      #
+      # @param group_file [String] path to the groups file
+      # @return [Hash] parsed groups
+      def parse_group_file(group_file)
+        return unless group_file
+        return unless File.exist?(group_file)
+
+        unless File.readable?(group_file)
+          Log.warn("The group file %s exist but it is not readable" % group_file)
+          return
+        end
+
+        Log.debug("Parsing groups file %s" % group_file)
+
+        File.read(group_file).each_line do |line|
+          next if line =~ /^(#.*|\s*)$/
+
+          parts = line.chomp.split
+
+          if parts[0] =~ /^([\w\.\-]+)$/
+            next if parts[1..-1].empty?
+
+            groups[ parts[0] ] = parts[1..-1]
+          else
+            Log.warn("Group file line '%s' is not in the expected format of 'group_name caller_id caller_id caller_id'" % line.chomp)
+          end
+        end
+
+        groups
+      end
+
+      # Determines if any of the groups have the caller in them
+      #
+      # @param groups [String,nil] space seperated list of groups
+      # @return [Boolean]
+      def caller_in_groups?(group_names)
+        return false unless group_names
+
+        group_names.to_s.split.select do |group|
+          next unless group =~ /^([\w\.\-]+)$/
+
+          groups.fetch(group, []).include?(caller_id)
+        end.any?
+      end
+
+      # Determine if the caller is any of the callerids
+      #
+      # @param caller_ids [String] space seperated list of caller ids
+      # @return [Boolean]
+      def caller_in_callerids?(caller_ids)
+        return false unless caller_ids
+
+        caller_ids.to_s.include?(caller_id)
+      end
+
+      def action_in_actions?(actions)
+        actions.split.include?(action)
+      end
+
       # Check if a request made by a caller matches the state defined in the policy
+      #
+      # @param rpccaller [String] the rpccaller as per the policy line
+      # @param action [String] the actions as per the policy line
+      # @param facts [String] the facts as per the policy line
+      # @param classes [String] the facts as per the policy line
+      # @return [Boolean]
       def check_policy(rpccaller, actions, facts, classes)
         # If we have a wildcard caller or the caller matches our policy line
-        # then continue else skip this policy line\
-        if (rpccaller != '*') && (! rpccaller || ! rpccaller.split.include?(@caller))
-          return false
-        end
+        # then continue else skip this policy line
+        return false unless rpccaller == '*' || caller_in_callerids?(rpccaller) || caller_in_groups?(rpccaller)
 
         # If we have a wildcard actions list or the request action is in the list
         # of actions in the policy line continue, else skip this policy line
-        if (actions != '*') && !(actions.split.include?(@action))
-          return false
-        end
+        return false unless actions == '*' || action_in_actions?(actions)
 
-        unless classes
-          return parse_compound(facts)
-        else
-          return parse_facts(facts) && parse_classes(classes)
-        end
+        return parse_facts(facts) && parse_classes(classes) if classes
+
+        parse_compound(facts)
       end
 
+      # Parses and validates the facts from a policy line
+      #
+      # @param facts [String] facts as per the policy line
+      # @return [Boolean]
       def parse_facts(facts)
         return true if facts == '*'
 
@@ -98,6 +173,10 @@ module MCollective
         true
       end
 
+      # Parses and validates the classes from the policy line
+      #
+      # @param classes [String] classes as per the policy line
+      # @return [Boolean]
       def parse_classes(classes)
         return true if classes == '*'
 
@@ -112,6 +191,10 @@ module MCollective
         true
       end
 
+      # Parses and validates a fact from the policy line
+      #
+      # @param fact [String] a standard fact filter format fact
+      # @return [Boolean]
       def lookup_fact(fact)
         if fact =~ /(.+)(<|>|=|<=|>=)(.+)/
           lv = $1
@@ -126,6 +209,10 @@ module MCollective
         end
       end
 
+      # Parses a class expression and validates it
+      #
+      # @param klass [String] class name to lookup and validate
+      # @return [Boolean]
       def lookup_class(klass)
         if klass =~ /(.+)(<|>|=|<=|>=)(.+)/
           Log.warn("Fact found where class was expected")
@@ -135,28 +222,36 @@ module MCollective
         end
       end
 
+      # Looks up and validates either a class or a fact
+      #
+      # @param token [String] either a fact in fact filter format or a class
+      # @return [Boolean]
       def lookup(token)
-        if token =~  /(.+)(<|>|=|<=|>=)(.+)/
+        if token =~ /(.+)(<|>|=|<=|>=)(.+)/
           return lookup_fact(token)
         else
           return lookup_class(token)
         end
       end
 
+      # Determines full path to the policy file
+      #
       # Here we lookup the full path of the policy file. If the policyfile
       # does not exist, we check to see if a default file was set and
       # determine its full path. If no default file exists, or default was
       # not specified, we return false.
+      #
+      # @return [String,Boolean] full file path else false
       def lookup_policy_file
-        policy_file = File.join(@configdir, "policies", "#{@agent}.policy")
+        policy_file = File.join(@configdir, "policies", "#{agent}.policy")
 
         Log.debug("Looking for policy in #{policy_file}")
 
         return policy_file if File.exist?(policy_file)
 
-        if @config.pluginconf.fetch('actionpolicy.enable_default', 'n') =~ /^1|y/i
-          defaultname = @config.pluginconf.fetch('actionpolicy.default_name', 'default')
-          default_file = File.join(@configdir, "policies", "#{defaultname}.policy")
+        if config.pluginconf.fetch('actionpolicy.enable_default', 'n') =~ /^1|y/i
+          defaultname = config.pluginconf.fetch('actionpolicy.default_name', 'default')
+          default_file = File.join(configdir, "policies", "#{defaultname}.policy")
 
           Log.debug("Initial lookup failed: looking for policy in #{default_file}")
 
@@ -164,10 +259,22 @@ module MCollective
         end
 
         Log.debug('Could not find any policy files.')
-        nil
+
+        false
+      end
+
+
+      # Determines full path to the groups file
+      #
+      # @return [String] path to the file
+      def lookup_groups_file
+        File.join(configdir, "policies", "groups")
       end
 
       # Evalute a compound statement and return its truth value
+      #
+      # @param statement [String] a standard compound filter string
+      # @return [Boolean]
       def eval_statement(statement)
         token_type = statement.keys.first
         token_value = statement.values.first
@@ -186,6 +293,10 @@ module MCollective
         end
       end
 
+      # Determines if a string is a compound filter
+      #
+      # @param list [String] a standard compound filter string
+      # @return [Boolean]
       def is_compound?(list)
         list.split.each do |token|
           if token =~ /^!|^not$|^or$|^and$|\(.+\)/
@@ -196,6 +307,10 @@ module MCollective
         false
       end
 
+      # Parse and evaluate a compound filter string
+      #
+      # @param list [String] compound filter
+      # @return [Boolean]
       def parse_compound(list)
         stack = Matcher.create_compound_callstack(list)
 
@@ -209,6 +324,10 @@ module MCollective
         eval(stack.join(' '))
       end
 
+      # Log and raise an appropriate error on deny
+      #
+      # @param logline [String] line to log in the log file
+      # @raise [RPCAborted] standard non specific failure error
       def deny(logline)
         Log.debug(logline)
 


### PR DESCRIPTION
This adds the ability to specify groups made up of many callerids
in a file called policies/groups

This groups file is then consulted whenever a policy line mentions a
group by name and membership of the caller is asserted

Also does a first run through making YARD commends and some test tweaks
and modernisation.